### PR TITLE
Allow to override build date

### DIFF
--- a/lib/ronn/document.rb
+++ b/lib/ronn/document.rb
@@ -171,6 +171,7 @@ module Ronn
     # the current time.
     def date
       return @date if @date
+      return Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime if not ENV['SOURCE_DATE_EPOCH'].nil?
       return File.mtime(path) if File.exist?(path)
       Time.now
     end


### PR DESCRIPTION
Allow to override build date
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use ISO-8601 date format to be understood everywhere.
And use UTC to be independent of timezones.

Based on https://github.com/rtomayko/ronn/pull/98 by Chris Lamb.